### PR TITLE
Add installation instructions for Ubuntu and Debian

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,3 +30,10 @@ Use `develop` branch for development, use `release` branch for last stable relea
 
     `dnf install php-pecl-pcov`
 
+* **Ubuntu** Setup Ubuntu PPA [ppa:ondrej/php](https://launchpad.net/~ondrej/+archive/ubuntu/php/)
+
+    `apt install php-pcov`
+
+* **Debian** Setup Debian DPA [packages.sury.org/php](https://packages.sury.org/php/) 
+
+    `apt install php-pcov`


### PR DESCRIPTION
Add installation instructions for Ubuntu and Debian based on the `deb.sury.org` packages.
See: https://github.com/oerdnj/deb.sury.org/issues/1138