### PR TITLE
Add a note about incompatibility with Blackfire

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ When PCOV is enabled by configuration `pcov.enabled=1`:
 
   * interoperability with Xdebug is not possible
   * interoperability with phpdbg is not possible
+  * interoperability with Blackfire profiler is not possible
 
 At an internals level, the executor function is overriden by pcov, so any extension or SAPI which does the same will be broken.
 
@@ -111,6 +112,7 @@ When PCOV is disabled by configuration `pcov.enabled=0`:
   * PCOV is zero cost - code runs at full speed
   * Xdebug may be loaded
   * phpdbg may be executed
+  * Blackfire probe may be loaded
 
 At an internals level, the executor function is untouched, and pcov allocates no memory.
 


### PR DESCRIPTION
Blackfire is a profiler for PHP, Python and Go.

The PHP extension (aka "the probe") [has known incompatibility with Pcov](https://support.blackfire.io/en/articles/3669196-known-incompatibilities-with-the-php-probe), for the same reasons than for Xdebug and phpdbg.
The result is an erratic, non-consistent profile.

This PR clearly states that Pcov cannot be used together with Blackfire.