### PR TITLE
Fix file name interning

### DIFF
--- a/pcov.c
+++ b/pcov.c
@@ -885,7 +885,7 @@ const zend_function_entry php_pcov_functions[] = {
 /* {{{ pcov_module_deps[] */
 static const zend_module_dep pcov_module_deps[] = {
 	ZEND_MOD_REQUIRED("pcre")
-	{NULL, NULL, NULL}
+	ZEND_MOD_END
 }; /* }}} */
 
 /* {{{ pcov_module_entry

--- a/php_pcov.h
+++ b/php_pcov.h
@@ -49,7 +49,6 @@ ZEND_BEGIN_MODULE_GLOBALS(pcov)
 	php_coverage_t   *start;
 	php_coverage_t  **next;
 	php_coverage_t  **last;
-	HashTable         filenames;
 	HashTable         waiting;
 	HashTable         files;
 	HashTable         ignores;


### PR DESCRIPTION
Use zend_new_interned_string() instead of hand-rolled interning implementation. Otherwise there may be use-after-frees depending on shutdown order, where we unconditionally free the filename strings, while they may still be referenced by globals in other modules.

The current code was introduced in https://github.com/krakjoe/pcov/commit/b5531d34711a71d2666c3e5d02d3d8ff7234e228. I think it was trying to work around the missing `zend_string_copy()` call?