### PR TITLE
Failing test for anonymous functions and code coverage not working

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,6 +79,16 @@ environment:
                   VC: vs16
                   PHP_VER: 8.0.3
                   TS: 0
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x64
+                  VC: vs16
+                  PHP_VER: 8.1.1
+                  TS: 1
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x86
+                  VC: vs16
+                  PHP_VER: 8.1.1
+                  TS: 0
 
 build_script:
         ps: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - valgrind
 php:
   - 8.0
+  - 8.1
   - nightly
 
 env:

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,0 +1,38 @@
+--TEST--
+anonymous function
+--SKIPIF--
+<?php if (!extension_loaded("pcov")) print "skip"; ?>
+--INI--
+pcov.enabled = 1
+--FILE--
+<?php
+\pcov\start();
+$a = function() {
+    return 'a';
+};
+$a();
+\pcov\stop();
+var_dump(\pcov\collect());
+?>
+--EXPECTF--
+array(1) {
+  ["%s%e007.php"]=>
+  array(8) {
+    [2]=>
+    int(-1)
+    [3]=>
+    int(1)
+    [5]=>
+    int(1)
+    [6]=>
+    int(1)
+    [7]=>
+    int(1)
+    [8]=>
+    int(-1)
+    [10]=>
+    int(-1)
+    [4]=>
+    int(1)
+  }
+}


### PR DESCRIPTION
This PR adds a failing test for anonymous functions not being included in coverage since PHP8.1. See #70

This also looks to uncover an issue with closing braces also not being covered since PHP 8.0. See #76
