### PR TITLE
generate arginfo from stub

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,16 +29,6 @@ cache:
 environment:
         BIN_SDK_VER: 2.2.0
         matrix:
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x64
-                  VC: vc14
-                  PHP_VER: 7.1.33
-                  TS: 1
-                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-                  ARCH: x86
-                  VC: vc14
-                  PHP_VER: 7.1.33
-                  TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15

--- a/pcov.stub.php
+++ b/pcov.stub.php
@@ -1,0 +1,18 @@
+<?php
+
+/** @generate-function-entries */
+
+namespace pcov;
+
+function start(): void {}
+
+function stop(): void {}
+
+function collect(int $type=\pcov\all, array $filter = []): ?array {}
+
+function clear(bool $files = false): void {}
+
+function waiting(): ?array {}
+
+function memory(): ?int {}
+

--- a/pcov_arginfo.h
+++ b/pcov_arginfo.h
@@ -1,0 +1,41 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: d2cebacd7516b58ebb9ce549595ee2b8ce3c3d6d */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcov_start, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_pcov_stop arginfo_pcov_start
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcov_collect, 0, 0, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "pcov\\all")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filter, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcov_clear, 0, 0, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, files, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcov_waiting, 0, 0, IS_ARRAY, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcov_memory, 0, 0, IS_LONG, 1)
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(start);
+ZEND_FUNCTION(stop);
+ZEND_FUNCTION(collect);
+ZEND_FUNCTION(clear);
+ZEND_FUNCTION(waiting);
+ZEND_FUNCTION(memory);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_NS_FE("pcov", start, arginfo_pcov_start)
+	ZEND_NS_FE("pcov", stop, arginfo_pcov_stop)
+	ZEND_NS_FE("pcov", collect, arginfo_pcov_collect)
+	ZEND_NS_FE("pcov", clear, arginfo_pcov_clear)
+	ZEND_NS_FE("pcov", waiting, arginfo_pcov_waiting)
+	ZEND_NS_FE("pcov", memory, arginfo_pcov_memory)
+	ZEND_FE_END
+};


### PR DESCRIPTION
add return type info for all functions
add default values in reflection (PHP 8)
drop support for PHP 7.1


Probably worth to bump version to **1.1.0-dev**