### PR TITLE
Fix GH-96: Compile error with PHP 8.1: use option -std=c99 or -std=gn…

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -10,7 +10,7 @@ if test "$PHP_PCOV" != "no"; then
   AC_MSG_CHECKING(PHP version)
 
   if test $PHP_VERSION -gt 80099; then
-    PHP_NEW_EXTENSION(pcov, pcov.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+    PHP_NEW_EXTENSION(pcov, pcov.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -std=c99)
   else
       if test $PHP_VERSION -lt 70100; then
         AC_MSG_ERROR([pcov supports PHP 7.1+])


### PR DESCRIPTION
…u99 to compile your code

Explicitly require the C99 standard when compiling for PHP >= 8, which is what PHP 8 itself requires anyway too.