### PR TITLE
pcov: Extended statements avoid opcache issues

### DIFF
--- a/pcov.c
+++ b/pcov.c
@@ -495,6 +495,10 @@ PHP_RINIT_FUNCTION(pcov)
 	CG(compiler_options) |= ZEND_COMPILE_NO_JUMPTABLES;
 #endif
 
+#ifdef ZEND_COMPILE_EXTENDED_STMT
+	CG(compiler_options) |= ZEND_COMPILE_EXTENDED_STMT;
+#endif
+
 	if  (!zend_compile_file_function) {
 		zend_compile_file_function = zend_compile_file;
 		zend_compile_file          = php_pcov_compile_file;


### PR DESCRIPTION
Opcache has a tendency to optimize away the necessary details to correctly produce code coverage information. The extended statements flag prevents the optimizer from making these lines disappear.

Props @derickr, @sebastianbergmann, @cmb69

Fixes #101

For the `ifdef`, I followed the pattern that already existed in the file to check for the defined constant instead of the specific PHP version. Please feel free to edit as desired.